### PR TITLE
Atualiza a seção Contribuindo no README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,11 @@ POST /api/produtos/<produto_id>/saida-estoque/
 
 ## Contribuindo
 
-1. Faça um fork do projeto
-2. Crie uma branch para sua feature (`git checkout -b feature/nova-feature`)
-3. Commit suas mudanças (`git commit -m 'Adicionando nova feature'`)
-4. Push para a branch (`git push origin feature/nova-feature`)
-5. Abra um Pull Request
+1. Abra uma issue no repositório para descrever o problema ou a funcionalidade que você está trabalhando.
+2. Crie uma branch a partir da issue. O nome da branch deve idealmente referenciar o número da issue.
+3. Faça suas alterações na nova branch e faça commit delas.
+4. Envie a branch para o repositório.
+5. Abra um pull request da sua branch para a branch principal.
+6. Na descrição do pull request, inclua a frase `close #issue_number` onde `issue_number` é o número da issue que você deseja fechar. Isso fechará automaticamente a issue quando o pull request for mesclado.
+
+Por exemplo, se o número da issue for 42, você escreveria `close #42` na descrição do pull request.


### PR DESCRIPTION
Atualizar a seção "Contribuindo" em `README.md` para incluir instruções para abrir um problema primeiro, criar uma ramificação a partir do problema e abrir uma PR que encerra o problema usando 'close #'.

* Adicionar instruções para abrir um problema primeiro na seção "Contribuindo".
* Adicionar instruções para criar uma ramificação a partir do problema na seção "Contribuindo".
* Adicionar instruções para abrir uma PR que encerra o problema usando 'close #' na seção "Contribuindo".
* Incluir etapas detalhadas sobre como vincular uma solicitação de pull a um problema usando 'close #issue_number' na seção "Contribuindo".